### PR TITLE
Do not use 'org.gradlex.java-module-dependencies'

### DIFF
--- a/src/main/kotlin/software.sava.build.check.dependencies.gradle.kts
+++ b/src/main/kotlin/software.sava.build.check.dependencies.gradle.kts
@@ -1,13 +1,13 @@
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesOrderingCheck
+import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesScopeCheck
 
 plugins {
   id("java")
   id("com.autonomousapps.dependency-analysis")
-  id("org.gradlex.java-module-dependencies")
 }
 
 tasks.withType<ModuleDirectivesOrderingCheck>().configureEach { enabled = false }
 
 tasks.check {
-  dependsOn(tasks.checkAllModuleInfo)
+  dependsOn(tasks.withType<ModuleDirectivesScopeCheck>())
 }

--- a/src/main/kotlin/software.sava.build.feature.test.gradle.kts
+++ b/src/main/kotlin/software.sava.build.feature.test.gradle.kts
@@ -2,7 +2,6 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 
 plugins {
   id("java")
-  id("org.gradlex.java-module-dependencies")
   id("org.gradlex.java-module-testing")
 }
 


### PR DESCRIPTION
Somehow this triggers a "accessing non-serializable type `org.gradle.api.Project` caused by invocation `getProject`" during stand-alone plugin compilation.

This should fix the currently failing build on `main`.