### PR TITLE
Tune publishing setup for more precision and better error handling

### DIFF
--- a/.github/workflows/gradle_plugin_publish.yml
+++ b/.github/workflows/gradle_plugin_publish.yml
@@ -22,18 +22,21 @@ jobs:
           website: ${{ vars.JDK_SRC }}
           release: ${{ vars.GRADLE_JAVA_VERSION }}
 
+      - name: Check
+        run: ./gradlew --stacktrace -Psign=true -Pversion=${{ github.ref_name }} check
+
       - name: Maven Central
-        run: ./gradlew check publishPluginMavenPublicationToCentralPortal -Pversion=${{ github.ref_name }} -Psign=true --stacktrace
+        run: ./gradlew --stacktrace -Psign=true -Pversion=${{ github.ref_name }} :publishPluginMavenPublicationToCentralPortal
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PUBLISH_SECRET: ${{ secrets.GPG_PUBLISH_SECRET }}
           GPG_PUBLISH_PHRASE: ${{ secrets.GPG_PUBLISH_PHRASE }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_CENTRAL_SECRET: ${{ secrets.MAVEN_CENTRAL_SECRET }}
 
       - name: Github Packages
-        run: ./gradlew check publish -Pversion=${{ github.ref_name }} -Psign=true --stacktrace
+        run: ./gradlew --stacktrace -Psign=true -Pversion=${{ github.ref_name }} :publishToGitHubPackages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PUBLISH_SECRET: ${{ secrets.GPG_PUBLISH_SECRET }}
           GPG_PUBLISH_PHRASE: ${{ secrets.GPG_PUBLISH_PHRASE }}
+          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ env.GITHUB_ACTOR }}
+          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,27 @@ jobs:
           jdk-src: ${{ vars.JDK_SRC }}
           gradle-java-version: ${{ vars.GRADLE_JAVA_VERSION }}
 
-      - name: Publish Packages
+      - name: Check
         id: publish
         run: |
-          ./gradlew --stacktrace -Psign=true -PjavaVersion=${{ steps.setup.outputs.java-version }} -Pversion=${{ github.ref_name }} check :aggregation:publishToGitHubPackages :aggregation:publishAggregationToCentralPortal
+          ./gradlew --stacktrace -Psign=true -PjavaVersion=${{ steps.setup.outputs.java-version }} -Pversion=${{ github.ref_name }} check
+
+      - name: Maven Central
+        id: publish
+        run: |
+          ./gradlew --stacktrace -Psign=true -PjavaVersion=${{ steps.setup.outputs.java-version }} -Pversion=${{ github.ref_name }} :aggregation:publishAggregationToCentralPortal
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PUBLISH_SECRET: ${{ secrets.GPG_PUBLISH_SECRET }}
           GPG_PUBLISH_PHRASE: ${{ secrets.GPG_PUBLISH_PHRASE }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_CENTRAL_SECRET: ${{ secrets.MAVEN_CENTRAL_SECRET }}
+
+      - name: Github Packages
+        id: publish
+        run: |
+          ./gradlew --stacktrace -Psign=true -PjavaVersion=${{ steps.setup.outputs.java-version }} -Pversion=${{ github.ref_name }} :aggregation:publishToGitHubPackages
+        env:
+          GPG_PUBLISH_SECRET: ${{ secrets.GPG_PUBLISH_SECRET }}
+          GPG_PUBLISH_PHRASE: ${{ secrets.GPG_PUBLISH_PHRASE }}
+          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ env.GITHUB_ACTOR }}
+          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/kotlin/software.sava.build.feature.publish.gradle.kts
+++ b/src/main/kotlin/software.sava.build.feature.publish.gradle.kts
@@ -12,13 +12,6 @@ val productName = isolated.rootProject.name
 val licenseName = providers.fileContents(isolated.rootProject.projectDirectory.file("LICENSE")).asText.map { it.lines().first().trim() }
 val vcs = "https://github.com/sava-software/${productName}"
 
-val gprUser = providers.environmentVariable("GITHUB_ACTOR")
-  .orElse(providers.gradleProperty("gpr.user.write"))
-  .orElse("")
-val gprToken = providers.environmentVariable("GITHUB_TOKEN")
-  .orElse(providers.gradleProperty("gpr.token.write"))
-  .orElse("")
-
 val signingKey = providers.environmentVariable("GPG_PUBLISH_SECRET").orNull
 val signingPassphrase = providers.environmentVariable("GPG_PUBLISH_PHRASE").orNull
 val publishSigningEnabled = providers.gradleProperty("sign").getOrElse("false").toBoolean()
@@ -99,12 +92,10 @@ publishing {
 
   repositories {
     maven {
-      name = "GithubPackages"
+      name = "githubPackages"
       url = uri("https://maven.pkg.github.com/sava-software/${productName}")
-      credentials {
-        username = gprUser.get()
-        password = gprToken.get()
-      }
+      // https://docs.gradle.org/current/samples/sample_publishing_credentials.html
+      credentials(PasswordCredentials::class)
     }
   }
 }


### PR DESCRIPTION
- Use credentials(PasswordCredentials::class) for Configuration Cache compatibility
  Now use standard ENV variables: https://docs.gradle.org/current/samples/sample_publishing_credentials.html
- Only publish required marker POM to GitHub packages
- Split pipeline into three steps: check, Maven Central, GH Packages